### PR TITLE
Fix installation on CentOS

### DIFF
--- a/tasks/fedora.yml
+++ b/tasks/fedora.yml
@@ -1,39 +1,38 @@
 ---
-- name: redhat | installing pre-reqs
-  yum:
+- name: fedora | installing pre-reqs
+  dnf:
     name: "{{ item }}"
     state: present
   with_items:
-    - epel-release
     - wget
 
-- name: redhat | installing erlang
-  yum:
+- name: fedora | installing erlang
+  dnf:
     name: "erlang"
     state: present
 
-- name: redhat | adding RabbitMQ public GPG key
+- name: fedora | adding RabbitMQ public GPG key
   rpm_key:
     key: "{{ rabbitmq_redhat_repo_key }}"
     state: present
 
-- name: redhat | downloading RabbitMQ
+- name: fedora | downloading RabbitMQ
   get_url:
     url: "{{ rabbitmq_redhat_url }}/{{ rabbitmq_redhat_package }}"
     dest: "/opt/{{ rabbitmq_redhat_package }}"
 
-- name: redhat | installing RabbitMQ
-  yum:
+- name: fedora | installing RabbitMQ
+  dnf:
     name: "/opt/{{ rabbitmq_redhat_package }}"
     state: present
 
-- name: redhat | starting and enabling RabbitMQ service
+- name: fedora | starting and enabling RabbitMQ service
   service:
     name: "rabbitmq-server"
     state: started
     enabled: yes
 
-- name: redhat | enabling the RabbitMQ Management Console
+- name: fedora | enabling the RabbitMQ Management Console
   rabbitmq_plugin:
     names: rabbitmq_management
     state: enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,8 +3,11 @@
   when: ansible_os_family == "Debian"
 
 - include: redhat.yml
-  when: ansible_os_family == "RedHat"
-  
+  when: ansible_distribution == "CentOS" or ansible_distribution == "Red Hat Enterprise Linux"
+
+- include: fedora.yml
+  when: ansible_distribution == "Fedora"
+
 - name: checking to see if already clustered
   stat: path=/etc/rabbitmq/clustered
   register: clustered


### PR DESCRIPTION
Hi.

Installation on CentOS are broken:
- epel-release and dnf can't be installed in one task, because dnf depends on epel-release
- dnf can't work with epel repo (`Failed to open: /var/cache/dnf` error)

I separated tasks for Fedora and CentOS/RHEL.
