### PR TITLE
Fix cluster reset

### DIFF
--- a/tasks/rabbitmq_clustering.yml
+++ b/tasks/rabbitmq_clustering.yml
@@ -1,9 +1,11 @@
 ---
 - name: rabbitmq_clustering | stopping rabbitmq app
   command: rabbitmqctl stop_app
+  when: inventory_hostname != "{{ rabbitmq_master }}"
 
 - name: rabbitmq_clustering | resetting rabbitmq app
   command: rabbitmqctl reset
+  when: inventory_hostname != "{{ rabbitmq_master }}"
 
 - name: rabbitmq_clustering | stopping rabbitmq-server
   service:
@@ -55,7 +57,7 @@
   when: inventory_hostname != "{{ rabbitmq_master }}"
 
 - name: rabbitmq_clustering | joining rabbitmq cluster
-  command: rabbitmqctl join_cluster 'rabbit@{{ rabbitmq_master }}'
+  command: rabbitmqctl join_cluster "rabbit@{{ hostvars[rabbitmq_master]['ansible_hostname'] }}"
   register: cluster_joined
   when: inventory_hostname != "{{ rabbitmq_master }}"
 


### PR DESCRIPTION
Prevent to stop_app in the master as it cannot be reset
if there is no nodes in the cluste[1]r. Also, when joining a cluster, the nodes
must use the short-hostname form of the master FQDN.

This works for me in CentOS 7 and should work in others distros.

1: Error: {no_running_cluster_nodes,\"You cannot leave a cluster if no online nodes are present.\"