### PR TITLE
Corrected an argument which is passed to 'with_items' of the 'lineinfile' module for evaluating list value

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Example Playbook
         regexp: "^{{ hostvars[item].ansible_ssh_host }} {{ item }} {{ item }}.{{ pri_domain_name }}"
         line: "{{ hostvars[item].ansible_ssh_host }} {{ item }} {{ item }}.{{ pri_domain_name }}"
         state: present
-      with_items: groups['all']
+      with_items: "{{ groups['all'] }}"
 
 - hosts: all
   become: true

--- a/playbook.yml
+++ b/playbook.yml
@@ -11,7 +11,7 @@
         regexp: "^{{ hostvars[item].ansible_ssh_host }} {{ item }} {{ item }}.{{ pri_domain_name }}"
         line: "{{ hostvars[item].ansible_ssh_host }} {{ item }} {{ item }}.{{ pri_domain_name }}"
         state: present
-      with_items: groups['all']
+      with_items: "{{ groups['all'] }}"
 
 - hosts: all
   become: true


### PR DESCRIPTION
Thank you for providing this useful playbook.

I want to correct a problem that this playbook has.
Currently, [this specification](https://github.com/mrlesmithjr/ansible-rabbitmq/blob/master/playbook.yml#L14) is handled as String.

This patch corrects it to evaluate as a list object.

Thank you.
