### PR TITLE
Add OracleLinux to RHEL

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,8 @@
 - include: redhat.yml
   when: >
         ansible_distribution == "CentOS" or
-        ansible_distribution == "Red Hat Enterprise Linux"
+        ansible_distribution == "Red Hat Enterprise Linux" or
+        ansible_distribution == "OracleLinux"
 
 - include: fedora.yml
   when: ansible_distribution == "Fedora"


### PR DESCRIPTION
This PR add OracleLinux to RHEL family OS.
I've tested this and it worked.
