### PR TITLE
Update rabbitmq.config.j2

### DIFF
--- a/templates/etc/rabbitmq/rabbitmq.config.j2
+++ b/templates/etc/rabbitmq/rabbitmq.config.j2
@@ -1,9 +1,5 @@
 [
  {rabbit, [
-{% if rabbitmq_listeners is not defined %}
-   {tcp_listeners, [{{ rabbitmq_listen_port }}]}
-{% elif rabbitmq_listeners is defined %}
-   {tcp_listeners, [{% for item in rabbitmq_listeners %}{"{{ item }}", {{ rabbitmq_listen_port }}}{% if not loop.last %}, {% endif %}{% endfor %}]}
-{% endif %}
+   {tcp_listeners, [{% for item in rabbitmq_listeners %}{"{{ item }}", {{ rabbitmq_listen_port }}}{% if not loop.last %}, {% endif %} {% else %} {{rabbitmq_listen_port}} {% endfor %}]}
   ]}
 ].


### PR DESCRIPTION
rabbitmq_listeners is always defined but it was empty.