### PR TITLE
add ssl listener support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,18 @@ rabbitmq_listeners: []
   # - '127.0.0.1'
   # - '::1'
 
+rabbitmq_ssl_enable: false
+rabbitmq_ssl_port: 5671
+rabbitmq_ssl_listeners: []
+  # - '127.0.0.1'
+  # - '::1'
+rabitmq_ssl_options: {}
+  # cacertfile: '"/path/to/testca/cacert.pem"'
+  # certfile: '"/path/to/server/cert.pem"'
+  # keyfile: '"/path/to/server/key.pem"'
+  # verify: verify_peer
+  # fail_if_no_peer_cert: "false"
+
 # Defines the inventory host that should be considered master
 rabbitmq_master: []
 

--- a/templates/etc/rabbitmq/rabbitmq.config.j2
+++ b/templates/etc/rabbitmq/rabbitmq.config.j2
@@ -1,9 +1,25 @@
 [
  {rabbit, [
-{% if rabbitmq_listeners is not defined %}
+{% if rabbitmq_listeners is not defined or (rabbitmq_listeners | length) == 0 %}
    {tcp_listeners, [{{ rabbitmq_listen_port }}]}
 {% elif rabbitmq_listeners is defined %}
    {tcp_listeners, [{% for item in rabbitmq_listeners %}{"{{ item }}", {{ rabbitmq_listen_port }}}{% if not loop.last %}, {% endif %}{% endfor %}]}
+{% endif %}
+{% if rabbitmq_ssl_enable %}
+   ,
+   {num_ssl_acceptors, 10},
+{% if rabbitmq_ssl_listeners is not defined or (rabbitmq_ssl_listeners | length) == 0 %}
+   {ssl_listeners, [{{ rabbitmq_ssl_port }}]},
+{% elif rabbitmq_listeners is defined %}
+   {tcp_listeners, [{% for item in rabbitmq_ssl_listeners %}{"{{ item }}", {{ rabbitmq_ssl_port }}}{% if not loop.last %}, {% endif %}{% endfor %}]},
+{% endif %}
+{% if rabbitmq_ssl_options is defined and (rabbitmq_ssl_options | length ) > 0 %}
+   {ssl_options, [
+{% for key in rabbitmq_ssl_options %}
+        { {{ key }}, {{ rabbitmq_ssl_options[key] }}}{% if not loop.last %}, {% endif %}
+{% endfor %}
+   ]}
+{% endif %}
 {% endif %}
   ]}
 ].


### PR DESCRIPTION
The current version lack ssl listener support so this PR aims at creating it. It fixes a small issue with rabbitmq.config.j2 template file when tcp_listeners is an empty array