### PR TITLE
Allow debian install from bintray

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,12 @@ rabbitmq_config_service: false
 rabbitmq_config_file: 'etc/rabbitmq/rabbitmq.config.j2'
 
 rabbitmq_debian_repo: 'deb http://www.rabbitmq.com/debian/ testing main'
+#other repos
+#rabbitmq_debian_repo: deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main #bintray
 rabbitmq_debian_repo_key: 'https://www.rabbitmq.com/rabbitmq-release-signing-key.asc'
+#rabbitmq_debian_repo_key: https://bintray.com/user/downloadSubjectPublicKey?username=rabbitmq
+rabbitmq_debian_erlang_from_rabbit: false
+#rabbitmq_debian_version: 3.7.9 # current version if not defined
 
 # Defines if setting up a rabbitmq cluster
 rabbitmq_enable_clustering: false

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -9,14 +9,21 @@
   apt_repository:
     repo: "{{ rabbitmq_debian_repo }}"
     state: present
-  register: "rabbitmq_repo_added"
   become: true
 
-- name: debian | updating apt cache
-  apt:
-    update_cache: yes
+- name: debian | add Rabbitmq erlang repo key
+  apt_key:
+    url: https://bintray.com/user/downloadSubjectPublicKey?username=rabbitmq-erlang
+    state: present
   become: true
-  when: rabbitmq_repo_added.changed
+  when: rabbitmq_debian_erlang_from_rabbit
+
+- name: debian | add Rabbitmq erlang repo
+  apt_repository:
+    repo: deb https://dl.bintray.com/rabbitmq-erlang/debian {{ ansible_distribution_release }} erlang
+    state: present
+  become: true
+  when: rabbitmq_debian_erlang_from_rabbit
 
 - name: debian | installing RabbitMQ server
   apt:
@@ -24,7 +31,7 @@
     state: present
   become: true
   with_items:
-    - rabbitmq-server
+    - rabbitmq-server{{ (rabbitmq_debian_version is defined) | ternary(['=',rabbitmq_debian_version] | join(''),'')}}
 
 - name: debian | enabling the RabbitMQ Management Console
   rabbitmq_plugin:


### PR DESCRIPTION
Debian rabbitmq legacy repository is not mentioned anymore in the documentation so I inserted a set of variable to choose to install rabbitmq from bintray repository. Since erlang packages in debian flavours are very outdate I also add the choice to use rabbitmq-erlang packages from bintray.
Defaults are made to keep the old behaviour.

This PR also add a variable to select which rabbitmq-server version to fetch from debian repository. The array join trick is not very elegant but I didn't find a better way to concatenate a string and a var in jinja