### PR TITLE
compatibility: make the role compatible with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 ---
 language: python
-python: "2.7"
+matrix:
+  include:
+    - python: '3.6'
+    - python: '2.7'
 
 # Use the new container infrastructure
 sudo: required

--- a/templates/etc/rabbitmq/rabbitmq-env.conf.j2
+++ b/templates/etc/rabbitmq/rabbitmq-env.conf.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 # Note that the variables do not have the RABBITMQ_ prefix.
 #
-{% for key,value in rabbitmq_env_config.iteritems() %}
+{% for key, value in rabbitmq_env_config.items() %}
 {{ key }}={{ value }}
 {% endfor %}


### PR DESCRIPTION
The `iteritems` function is not available in python3. Instead it's safe to use `.items()` on a dictionary in a for loop which will work with both python2 and python3.