### PR TITLE
debian: fix the use of 'rabbitmq_debian_version' variable

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -41,13 +41,12 @@
 
 - name: debian | installing RabbitMQ server
   apt:
-    name: ['rabbitmq-server']
+    name:
+      - rabbitmq-server{{ (rabbitmq_debian_version is defined) | ternary(['=',rabbitmq_debian_version] | join(''),'') }}
     state: present
   become: true
   register: result
   until: result is successful
-  with_items:
-    - rabbitmq-server{{ (rabbitmq_debian_version is defined) | ternary(['=',rabbitmq_debian_version] | join(''),'') }}
 
 - name: debian | enabling the RabbitMQ Management Console
   rabbitmq_plugin:


### PR DESCRIPTION
Right now the dedicated rabbitmq_debian_version variable was unused by
the debian installer. This PR fixes the debian install task to be
able to install a specific package version.