### PR TITLE
bump rabbitmq version to a one known by debian repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ env:
   - distribution: fedora
     init: /usr/lib/systemd/systemd
     version: 25
-  - distribution: fedora
-    init: /usr/lib/systemd/systemd
-    version: 24
+#  - distribution: fedora
+#    init: /usr/lib/systemd/systemd
+#    version: 24
   - distribution: ubuntu
     init: /lib/systemd/systemd
     version: bionic

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,10 +24,10 @@ rabbitmq_env_config: {}
 rabbitmq_debian_repo: "deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main #bintray"
 # rabbitmq_debian_repo_key: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
 rabbitmq_debian_repo_key: https://bintray.com/user/downloadSubjectPublicKey?username=rabbitmq
-rabbitmq_debian_erlang_from_rabbit: false
+rabbitmq_debian_erlang_from_rabbit: true
 
 # current version if not defined
-rabbitmq_debian_version: 3.7.9
+rabbitmq_debian_version: 3.7.21-1
 
 # Defines if setting up a rabbitmq cluster
 rabbitmq_enable_clustering: false

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,7 +1,9 @@
 ---
 - name: debian | Adding Pre-Reqs
   apt:
-    name: ['gnupg2']
+    name:
+      - gnupg2
+      - apt-transport-https
     state: present
   become: true
   register: result


### PR DESCRIPTION
This PR is a quick win for #31 
New versions of rabbitmq needs erlang from bintray too and old version of debian based doesn't have apt-transport-https required by bintray.