### PR TITLE
cloudsmith (or packagecloud) have replaced bintray. Use cloudsmith by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,14 +21,18 @@ rabbitmq_env_config: {}
 
 # rabbitmq_debian_repo: deb http://www.rabbitmq.com/debian/ testing main
 #other repos
-rabbitmq_debian_repo: "deb https://dl.bintray.com/rabbitmq/debian {{ ansible_distribution_release }} main #bintray"
-# rabbitmq_debian_repo_key: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
-rabbitmq_debian_repo_key: https://bintray.com/user/downloadSubjectPublicKey?username=rabbitmq
+rabbitmq_debian_repo: "deb https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/debian {{ ansible_distribution_release }} main"
+rabbitmq_debian_repo_key: "https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key"
+rabbitmq_debian_team_key: "0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
+
 rabbitmq_debian_erlang_from_rabbit: true
+rabbitmq_debian_erlang_repo: "deb https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/debian {{ ansible_distribution_release }} main"
+rabbitmq_debian_erlang_repo_key: "https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key"
+
 
 # current version if not defined
 rabbitmq_debian_version_defined: true
-rabbitmq_debian_version: 3.8.11-1
+rabbitmq_debian_version: 3.8.18-1
 
 # Defines if setting up a rabbitmq cluster
 rabbitmq_enable_clustering: false

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -10,9 +10,18 @@
   register: result
   until: result is successful
 
-- name: debian | adding RabbitMQ public GPG key to the apt repo
+- name: debian | adding RabbitMQ repo public GPG key to the apt repo
   apt_key:
     url: "{{ rabbitmq_debian_repo_key }}"
+    state: present
+  become: true
+  register: result
+  until: result is successful
+
+- name: debian | adding RabbitMQ team public GPG key to the apt repo
+  apt_key:
+    keyserver: keys.openpgp.org
+    id: "{{ rabbitmq_debian_team_key }}"
     state: present
   become: true
   register: result
@@ -26,9 +35,17 @@
   register: result
   until: result is successful
 
+- name: debian | adding RabbitMQ relang repo public GPG key to the apt repo
+  apt_key:
+    url: "{{ rabbitmq_debian_erlang_repo_key }}"
+    state: present
+  become: true
+  register: result
+  until: result is successful
+
 - name: debian | add Rabbitmq erlang repo
   apt_repository:
-    repo: deb https://dl.bintray.com/rabbitmq-erlang/debian {{ ansible_distribution_release }} erlang
+    repo: "{{ rabbitmq_debian_erlang_repo }}"
     state: present
   become: true
   when: rabbitmq_debian_erlang_from_rabbit


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Fixes #41 by changing the default repo for Debian to cloudsmith and makes the repo for erlang configurable (defaulting to cloudsmith again).

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
