### PR TITLE
The command ran by community.rabbitmq.rabbitmq_vhost must run as root

### DIFF
--- a/tasks/rabbitmq_vhosts.yml
+++ b/tasks/rabbitmq_vhosts.yml
@@ -3,6 +3,7 @@
   rabbitmq_vhost:
     name: "{{ item['name'] }}"
     state: "{{ item['state'] }}"
+  become: true
   with_items: "{{ rabbitmq_extra_vhosts }}"
   run_once: "{{ rabbitmq_enable_clustering is defined and rabbitmq_enable_clustering }}"
   register: rabbitmq_created_vhosts


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Just makes rabbitmq_vhost run as root, otherwise you get a page full of text that boils down to the simple error message;
> Only root or rabbitmq can run rabbitmqctl

I do not know if this issue has always existed, was added in a "recent" version of RabbitMQ or the ansible plugin included with the version of ansible I'm using.
Seems like a safe thing to add regardless though. Right after the call to `rabbitmq_vhost` is a `command` that runs rabbitmqctl as root.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
