### PR TITLE
Separate the creation of exchange(s), queue(s), and binding(s) from HA policies

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,13 @@ rabbitmq_config: []
 #   type: direct
 #   routing_key: logstash
 #   tags: "ha-mode=all,ha-sync-mode=automatic"
+# - queue_name: logstash-quorum
+#   durable: true
+#   exchange_name: logstash-quorum
+#   type: direct
+#   routing_key: logstash
+#   queue_type: quorum
+#   tags: "ha-mode=all,ha-sync-mode=automatic"
 # - policy_pattern: ".*"
 #   vhost: apps
 #   tags: "ha-mode=all,ha-sync-mode=automatic"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,9 +29,8 @@
 - include: rabbitmq_vhosts.yml
   when: rabbitmq_extra_vhosts is defined
 
-- include: rabbitmq_ha_config.yml
+- include: rabbitmq_config.yml
   when: >
-        rabbitmq_config_ha and
         rabbitmq_enable_clustering and
         rabbitmq_config is defined
 

--- a/tasks/rabbitmq_config.yml
+++ b/tasks/rabbitmq_config.yml
@@ -1,0 +1,42 @@
+---
+- name: rabbitmq_config | checking if rabbitmqadmin is installed
+  stat:
+    path: /usr/sbin/rabbitmqadmin
+  register: rabbitmqadmin_check
+
+- name: rabbit_config | Installing rabbitMQ admin
+  get_url:
+    url: http://guest:guest@localhost:15672/cli/rabbitmqadmin
+    dest: /usr/sbin/rabbitmqadmin
+    mode: u=rwx,g=rw,o=rw
+  become: true
+  notify: restart rabbitmq-server
+  when: not rabbitmqadmin_check['stat']['exists']
+
+- name: rabbitmq_config | creating exchange(s)
+  command: rabbitmqadmin declare exchange name={{ item['exchange_name'] }} type={{ item['type'] }} --vhost={{ item['vhost'] | default('/') }}
+  run_once: true
+  delegate_to: "{{ rabbitmq_master }}"
+  become: true
+  with_items: "{{ rabbitmq_config }}"
+  when: item['exchange_name'] is defined
+
+- name: rabbitmq_config | creating queue(s)
+  command: rabbitmqadmin declare queue name={{ item['queue_name'] }} durable={{ item['durable']|lower }} --vhost={{ item['vhost'] | default('/') }} queue_type={{ item['queue_type'] | default('classic') }}
+  run_once: true
+  delegate_to: "{{ rabbitmq_master }}"
+  become: true
+  when:
+    - item['queue_name'] is defined
+  with_items: "{{ rabbitmq_config }}"
+
+- include: rabbitmq_ha_config.yml
+  when: rabbitmq_config_ha
+
+- name: rabbitmq_config | creating binding(s)
+  command: rabbitmqadmin declare binding source={{ item['exchange_name'] }} destination_type="queue" destination={{ item['queue_name'] }} routing_key={{ item['routing_key'] }} --vhost={{ item['vhost'] | default('/') }} # noqa 204
+  run_once: true
+  delegate_to: "{{ rabbitmq_master }}"
+  become: true
+  with_items: "{{ rabbitmq_config }}"
+  when: item['exchange_name'] is defined and item['queue_name'] is defined

--- a/tasks/rabbitmq_ha_config.yml
+++ b/tasks/rabbitmq_ha_config.yml
@@ -1,35 +1,4 @@
 ---
-- name: rabbitmq_ha_config | checking if rabbitmqadmin is installed
-  stat:
-    path: /usr/sbin/rabbitmqadmin
-  register: rabbitmqadmin_check
-
-- name: rabbit_ha_config | Installing rabbitMQ admin
-  get_url:
-    url: http://guest:guest@localhost:15672/cli/rabbitmqadmin
-    dest: /usr/sbin/rabbitmqadmin
-    mode: u=rwx,g=rw,o=rw
-  become: true
-  notify: restart rabbitmq-server
-  when: not rabbitmqadmin_check['stat']['exists']
-
-- name: rabbitmq_ha_config | creating exchange(s)
-  command: rabbitmqadmin declare exchange name={{ item['exchange_name'] }} type={{ item['type'] }} --vhost={{ item['vhost'] | default('/') }}
-  run_once: true
-  delegate_to: "{{ rabbitmq_master }}"
-  become: true
-  with_items: "{{ rabbitmq_config }}"
-  when: item['exchange_name'] is defined
-
-- name: rabbitmq_ha_config | creating queue(s)
-  command: rabbitmqadmin declare queue name={{ item['queue_name'] }} durable={{ item['durable']|lower }} --vhost={{ item['vhost'] | default('/') }}
-  run_once: true
-  delegate_to: "{{ rabbitmq_master }}"
-  become: true
-  when:
-    - item['queue_name'] is defined
-  with_items: "{{ rabbitmq_config }}"
-
 - name: rabbitmq_ha_config | setting up ha on queue(s)
   rabbitmq_policy:
     name: "ha-all{{ policy_name }}"
@@ -45,11 +14,3 @@
   become: true
   when: item.queue_name is defined or item.policy_pattern is defined
   with_items: "{{ rabbitmq_config }}"
-
-- name: rabbitmq_ha_config | creating binding(s)
-  command: rabbitmqadmin declare binding source={{ item['exchange_name'] }} destination_type="queue" destination={{ item['queue_name'] }} routing_key={{ item['routing_key'] }} --vhost={{ item['vhost'] | default('/') }} # noqa 204
-  run_once: true
-  delegate_to: "{{ rabbitmq_master }}"
-  become: true
-  with_items: "{{ rabbitmq_config }}"
-  when: item['exchange_name'] is defined


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

I needed this role to create just exchanges and policies with integers.
But creating exchanges was tied in with policies that would pass all arguments as strings.
So I've separated out the part static part custom policies HA stuff from the exchange(s), queue(s), and binding(s).

I'm marking this as a breaking change, but I really don't think it is, I just haven't tested it well enough.
I also haven't been able to work out exactly when `queue_type` was added. Certainly it has been there for all of 3.8.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
