### PR TITLE
change apt-key because of deprecation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,18 +28,18 @@ rabbitmq_env_config: {}
 
 # rabbitmq_debian_repo: deb http://www.rabbitmq.com/debian/ testing main
 #other repos
-rabbitmq_debian_repo: "deb https://ppa1.novemberain.com/rabbitmq/rabbitmq-server/deb/ubuntu {{ ansible_distribution_release }} main"
+rabbitmq_debian_repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq-server.asc] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu {{ ansible_distribution_release }} main"
 rabbitmq_debian_repo_key: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key"
-rabbitmq_debian_team_key: "0x0A9AF2115F4687BD29803A206B73A36E6026DFCA"
+
 
 rabbitmq_debian_erlang_from_rabbit: true
-rabbitmq_debian_erlang_repo: "deb https://ppa1.novemberain.com/rabbitmq/rabbitmq-erlang/deb/ubuntu {{ ansible_distribution_release }} main"
+rabbitmq_debian_erlang_repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq-erlang.asc] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu {{ ansible_distribution_release }} main"
 rabbitmq_debian_erlang_repo_key: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key"
 
 
 # current version if not defined
 rabbitmq_debian_version_defined: true
-rabbitmq_debian_version: 3.12.10-1
+rabbitmq_debian_version: 3.13.7-1
 
 # Defines if setting up a rabbitmq cluster
 rabbitmq_enable_clustering: false

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -10,19 +10,10 @@
   register: result
   until: result is successful
 
-- name: debian | adding RabbitMQ repo public GPG key to the apt repo
-  ansible.builtin.apt_key:
+- name: debian | add RabbitMQ repo GPG Signin Keys
+  ansible.builtin.get_url:
     url: "{{ rabbitmq_debian_repo_key }}"
-    state: present
-  become: true
-  register: result
-  until: result is successful
-
-- name: debian | adding RabbitMQ team public GPG key to the apt repo
-  ansible.builtin.apt_key:
-    keyserver: keys.openpgp.org
-    id: "{{ rabbitmq_debian_team_key }}"
-    state: present
+    dest: "/usr/share/keyrings/rabbitmq-server.asc"
   become: true
   register: result
   until: result is successful
@@ -36,9 +27,9 @@
   until: result is successful
 
 - name: debian | adding RabbitMQ relang repo public GPG key to the apt repo
-  ansible.builtin.apt_key:
+  ansible.builtin.get_url:
     url: "{{ rabbitmq_debian_erlang_repo_key }}"
-    state: present
+    dest: "/usr/share/keyrings/rabbitmq-erlang.asc"
   become: true
   register: result
   until: result is successful

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -14,6 +14,7 @@
   ansible.builtin.get_url:
     url: "{{ rabbitmq_debian_repo_key }}"
     dest: "/usr/share/keyrings/rabbitmq-server.asc"
+    mode: "0644"
   become: true
   register: result
   until: result is successful
@@ -30,6 +31,7 @@
   ansible.builtin.get_url:
     url: "{{ rabbitmq_debian_erlang_repo_key }}"
     dest: "/usr/share/keyrings/rabbitmq-erlang.asc"
+    mode: "0644"
   become: true
   register: result
   until: result is successful


### PR DESCRIPTION
Replace apt_key with an get_url and modified repo sources

## Description

The apt-key functionality was deprecated and will be removed after ubuntu 24.04 and debian 12.

The simple solution is to download the key and work with the signed-by tag within the source list. I followed the installation guide from the official [rabbitmq docs](https://www.rabbitmq.com/docs/install-debian).

I also updated the rabbitmq-server version.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

---

I have a few questions about the Checklist:
- What are the pre-merge tests? I have not found any.
- I don't know what I should document an therefor I am not sure if I should check the point.
- I have never worked with molecule and I do not see any tests which I could follow

After all I can say, I have deployed a RabbitMQ Cluster with these changes.

If anything should be changes, please make a comment.