### PR TITLE
change deb repos

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -37,11 +37,11 @@ jobs:
           - ubuntu2404
         python-version: [3.13]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - uses: actions/cache@v4

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -31,9 +31,10 @@ jobs:
           # - fedora35
           # - rocky8
           # - ubuntu1604
-          - ubuntu1804
+          # - ubuntu1804
           - ubuntu2004
-          # - ubuntu2204
+          - ubuntu2204
+          - ubuntu2404
         python-version: [3.9]
     steps:
       - uses: actions/checkout@v3
@@ -43,7 +44,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -32,10 +32,10 @@ jobs:
           # - rocky8
           # - ubuntu1604
           # - ubuntu1804
-          - ubuntu2004
+          # - ubuntu2004
           - ubuntu2204
           - ubuntu2404
-        python-version: [3.9]
+        python-version: [3.13]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-executables-have-shebangs
@@ -14,19 +14,19 @@ repos:
         args: [--branch, develop, --branch, master, --branch, main]
       - id: trailing-whitespace
   - repo: https://github.com/ansible-community/ansible-lint
-    rev: v6.22.1
+    rev: v25.12.0
     hooks:
       - id: ansible-lint
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 25.11.0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.3.0
     hooks:
       - id: flake8
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.33.0
+    rev: v1.37.1
     hooks:
       - id: yamllint

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ rabbitmq_debian_erlang_repo_key: "https://github.com/rabbitmq/signing-keys/relea
 
 # current version if not defined
 rabbitmq_debian_version_defined: true
-rabbitmq_debian_version: 4.2.1
+rabbitmq_debian_version: 4.2.1-1
 
 # Defines if setting up a rabbitmq cluster
 rabbitmq_enable_clustering: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,12 +28,12 @@ rabbitmq_env_config: {}
 
 # rabbitmq_debian_repo: deb http://www.rabbitmq.com/debian/ testing main
 #other repos
-rabbitmq_debian_repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq-server.asc] https://deb1.rabbitmq.com/rabbitmq-server/{{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_release'] }} {{ ansible_facts['distribution_release'] }} main"
+rabbitmq_debian_repo: "deb [signed-by=/usr/share/keyrings/rabbitmq-server.asc] https://deb1.rabbitmq.com/rabbitmq-server/{{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_release'] }} {{ ansible_facts['distribution_release'] }} main"
 rabbitmq_debian_repo_key: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/rabbitmq-release-signing-key.asc"
 
 
 rabbitmq_debian_erlang_from_rabbit: true
-rabbitmq_debian_erlang_repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq-erlang.asc] https://deb1.rabbitmq.com/rabbitmq-erlang/{{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_release'] }} {{ ansible_facts['distribution_release'] }} main"
+rabbitmq_debian_erlang_repo: "deb [signed-by=/usr/share/keyrings/rabbitmq-erlang.asc] https://deb1.rabbitmq.com/rabbitmq-erlang/{{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_release'] }} {{ ansible_facts['distribution_release'] }} main"
 rabbitmq_debian_erlang_repo_key: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/rabbitmq-release-signing-key.asc"
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,18 +28,18 @@ rabbitmq_env_config: {}
 
 # rabbitmq_debian_repo: deb http://www.rabbitmq.com/debian/ testing main
 #other repos
-rabbitmq_debian_repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq-server.asc] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-server/deb/ubuntu {{ ansible_distribution_release }} main"
-rabbitmq_debian_repo_key: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-server.9F4587F226208342.key"
+rabbitmq_debian_repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq-server.asc] https://deb1.rabbitmq.com/rabbitmq-server/{{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_release'] }} {{ ansible_facts['distribution_release'] }} main"
+rabbitmq_debian_repo_key: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/rabbitmq-release-signing-key.asc"
 
 
 rabbitmq_debian_erlang_from_rabbit: true
-rabbitmq_debian_erlang_repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq-erlang.asc] https://ppa1.rabbitmq.com/rabbitmq/rabbitmq-erlang/deb/ubuntu {{ ansible_distribution_release }} main"
-rabbitmq_debian_erlang_repo_key: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/cloudsmith.rabbitmq-erlang.E495BB49CC4BBE5B.key"
+rabbitmq_debian_erlang_repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/rabbitmq-erlang.asc] https://deb1.rabbitmq.com/rabbitmq-erlang/{{ ansible_facts['distribution'] | lower }}/{{ ansible_facts['distribution_release'] }} {{ ansible_facts['distribution_release'] }} main"
+rabbitmq_debian_erlang_repo_key: "https://github.com/rabbitmq/signing-keys/releases/download/3.0/rabbitmq-release-signing-key.asc"
 
 
 # current version if not defined
 rabbitmq_debian_version_defined: true
-rabbitmq_debian_version: 3.13.7-1
+rabbitmq_debian_version: 4.2.1
 
 # Defines if setting up a rabbitmq cluster
 rabbitmq_enable_clustering: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,8 +70,8 @@ rabitmq_ssl_options: {}
 # fail_if_no_peer_cert: "false"
 
 rabbitmq_redhat_repo_key: https://github.com/rabbitmq/signing-keys/releases/download/3.0/rabbitmq-release-signing-key.asc
-rabbitmq_redhat_package: "rabbitmq-server-{{ rabbitmq_redhat_version }}-1.el{{ ansible_distribution_major_version }}.noarch.rpm"
-rabbitmq_redhat_url: "https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/rpm/el/{{ ansible_distribution_major_version }}/noarch"
+rabbitmq_redhat_package: "rabbitmq-server-{{ rabbitmq_redhat_version }}-1.el{{ ansible_facts['distribution_major_version'] }}.noarch.rpm"
+rabbitmq_redhat_url: "https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/rpm/el/{{ ansible_facts['distribution_major_version'] }}/noarch"
 rabbitmq_redhat_version: 3.12.10
 
 # Define extra vhosts to be created

--- a/molecule/shared/prepare.yml
+++ b/molecule/shared/prepare.yml
@@ -6,4 +6,4 @@
       ansible.builtin.apt:
         update_cache: true
       become: true
-      when: ansible_os_family == "Debian"
+      when: ansible_facts['os_family'] == "Debian"

--- a/molecule/ubuntu2204/molecule.yml
+++ b/molecule/ubuntu2204/molecule.yml
@@ -1,0 +1,39 @@
+---
+dependency:
+  name: galaxy
+  enabled: false
+  options:
+    role-file: requirements.yml
+driver:
+  name: docker
+lint: |
+  yamllint .
+  ansible-lint
+  flake8
+platforms:
+  - name: ubuntu2204
+    image: mrlesmithjr/ubuntu:22.04
+    privileged: true
+    command: /lib/systemd/systemd
+    # tmpfs:
+    #   - /run
+    #   - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    # groups: []
+provisioner:
+  name: ansible
+  env:
+    # Molecule used to add ${MOLECULE_PROJECT_DIRECTORY}/. to this
+    # path for us pre-25.2.0, but now we have to do it ourselves.  See
+    # ansible/molecule#4380 and
+    # https://github.com/ansible/molecule/releases/tag/v25.2.0 for
+    # more details.
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
+  playbooks:
+    converge: ../shared/converge.yml
+    prepare: ../shared/prepare.yml
+    verify: ../shared/verify.yml
+verifier:
+  name: ansible

--- a/molecule/ubuntu2204/verify.yml
+++ b/molecule/ubuntu2204/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Example assertion
+    ansible.builtin.assert:
+      that: true

--- a/molecule/ubuntu2404/molecule.yml
+++ b/molecule/ubuntu2404/molecule.yml
@@ -1,0 +1,39 @@
+---
+dependency:
+  name: galaxy
+  enabled: false
+  options:
+    role-file: requirements.yml
+driver:
+  name: docker
+lint: |
+  yamllint .
+  ansible-lint
+  flake8
+platforms:
+  - name: ubuntu2404
+    image: mrlesmithjr/ubuntu:24.04
+    privileged: true
+    command: /lib/systemd/systemd
+    # tmpfs:
+    #   - /run
+    #   - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    # groups: []
+provisioner:
+  name: ansible
+  env:
+    # Molecule used to add ${MOLECULE_PROJECT_DIRECTORY}/. to this
+    # path for us pre-25.2.0, but now we have to do it ourselves.  See
+    # ansible/molecule#4380 and
+    # https://github.com/ansible/molecule/releases/tag/v25.2.0 for
+    # more details.
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/..:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
+  playbooks:
+    converge: ../shared/converge.yml
+    prepare: ../shared/prepare.yml
+    verify: ../shared/verify.yml
+verifier:
+  name: ansible

--- a/molecule/ubuntu2404/verify.yml
+++ b/molecule/ubuntu2404/verify.yml
@@ -1,0 +1,9 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  tasks:
+  - name: Example assertion
+    ansible.builtin.assert:
+      that: true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,81 +1,58 @@
-ansible-compat==3.0.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-ansible-core==2.13.13 ; python_full_version >= "3.8.1" and python_version < "4.0"
-ansible-lint==6.8.7 ; python_full_version >= "3.8.1" and python_version < "4.0"
-ansible==6.6.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-arrow==1.3.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-astroid==2.15.8 ; python_full_version >= "3.8.1" and python_version < "4.0"
-attrs==23.1.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-binaryornot==0.4.4 ; python_full_version >= "3.8.1" and python_version < "4.0"
-black==22.12.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-bracex==2.4 ; python_full_version >= "3.8.1" and python_version < "4.0"
-certifi==2023.11.17 ; python_full_version >= "3.8.1" and python_version < "4.0"
-cffi==1.16.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-cfgv==3.4.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-chardet==5.2.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-charset-normalizer==3.3.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-click-help-colors==0.9.4 ; python_full_version >= "3.8.1" and python_version < "4.0"
-click==8.1.7 ; python_full_version >= "3.8.1" and python_version < "4.0"
-colorama==0.4.6 ; python_full_version >= "3.8.1" and python_version < "4.0" and (sys_platform == "win32" or platform_system == "Windows")
-cookiecutter==2.5.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-cryptography==41.0.7 ; python_full_version >= "3.8.1" and python_version < "4.0"
-dill==0.3.7 ; python_full_version >= "3.8.1" and python_version < "4.0"
-distlib==0.3.8 ; python_full_version >= "3.8.1" and python_version < "4.0"
-distro==1.8.0 ; python_full_version >= "3.8.1" and python_version < "4.0" and (sys_platform == "linux" or sys_platform == "linux2")
-docker==7.0.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-enrich==1.2.7 ; python_full_version >= "3.8.1" and python_version < "4.0"
-filelock==3.13.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-flake8==6.1.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-identify==2.5.33 ; python_full_version >= "3.8.1" and python_version < "4.0"
-idna==3.6 ; python_full_version >= "3.8.1" and python_version < "4.0"
-importlib-resources==6.1.1 ; python_full_version >= "3.8.1" and python_version < "3.9"
-isort==5.13.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-jinja2==3.1.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-jsonschema-specifications==2023.11.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-jsonschema==4.20.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-lazy-object-proxy==1.10.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-markdown-it-py==3.0.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-markupsafe==2.1.3 ; python_full_version >= "3.8.1" and python_version < "4.0"
-mccabe==0.7.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-mdurl==0.1.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-molecule-docker==2.1.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-molecule==4.0.4 ; python_full_version >= "3.8.1" and python_version < "4.0"
-molecule[docker]==4.0.4 ; python_full_version >= "3.8.1" and python_version < "4.0"
-mypy-extensions==1.0.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-nodeenv==1.8.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-packaging==23.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pathspec==0.12.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pkgutil-resolve-name==1.3.10 ; python_full_version >= "3.8.1" and python_version < "3.9"
-platformdirs==4.1.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pluggy==1.3.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pre-commit==2.21.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pycodestyle==2.11.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pycparser==2.21 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pyflakes==3.1.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pygments==2.17.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pylint==2.17.7 ; python_full_version >= "3.8.1" and python_version < "4.0"
-python-dateutil==2.8.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-python-slugify==8.0.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pywin32==306 ; python_full_version >= "3.8.1" and python_version < "4.0" and sys_platform == "win32"
-pyyaml==6.0.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-referencing==0.32.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-requests==2.31.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-resolvelib==0.8.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-rich==13.7.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-rpds-py==0.15.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-ruamel-yaml-clib==0.2.8 ; platform_python_implementation == "CPython" and python_version < "3.13" and python_full_version >= "3.8.1"
-ruamel-yaml==0.17.40 ; python_full_version >= "3.8.1" and python_version < "4.0"
-selinux==0.2.1 ; python_full_version >= "3.8.1" and python_version < "4.0" and (sys_platform == "linux" or sys_platform == "linux2")
-setuptools==69.0.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-six==1.16.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-subprocess-tee==0.4.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-text-unidecode==1.3 ; python_full_version >= "3.8.1" and python_version < "4.0"
-tomli==2.0.1 ; python_full_version >= "3.8.1" and python_full_version < "3.11.0a7"
-tomlkit==0.12.3 ; python_full_version >= "3.8.1" and python_version < "4.0"
-types-python-dateutil==2.8.19.14 ; python_full_version >= "3.8.1" and python_version < "4.0"
-typing-extensions==4.9.0 ; python_full_version >= "3.8.1" and python_version < "3.11"
-urllib3==2.1.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-virtualenv==20.25.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-wcmatch==8.5 ; python_full_version >= "3.8.1" and python_version < "4.0"
-wrapt==1.16.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-yamllint==1.33.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-zipp==3.17.0 ; python_full_version >= "3.8.1" and python_version < "3.9"
+ansible==13.0.0
+ansible-compat==25.12.0
+ansible-core==2.20.0
+ansible-lint==25.12.0
+attrs==25.4.0
+black==25.11.0
+bracex==2.6
+certifi==2025.11.12
+cffi==2.0.0
+cfgv==3.5.0
+charset-normalizer==3.4.4
+click==8.3.1
+click-help-colors==0.9.4
+cryptography==46.0.3
+distlib==0.4.0
+distro==1.9.0
+docker==7.1.0
+enrich==1.2.7
+filelock==3.20.0
+flake8==7.3.0
+identify==2.6.15
+idna==3.11
+Jinja2==3.1.6
+jsonschema==4.25.1
+jsonschema-specifications==2025.9.1
+markdown-it-py==4.0.0
+MarkupSafe==3.0.3
+mccabe==0.7.0
+mdurl==0.1.2
+molecule==25.12.0
+molecule-docker==2.1.0
+molecule-plugins==25.8.12
+mypy_extensions==1.1.0
+nodeenv==1.9.1
+packaging==25.0
+pathspec==0.12.1
+platformdirs==4.5.1
+pluggy==1.6.0
+pre_commit==4.5.0
+pycodestyle==2.14.0
+pycparser==2.23
+pyflakes==3.4.0
+Pygments==2.19.2
+pytokens==0.3.0
+PyYAML==6.0.3
+referencing==0.37.0
+requests==2.32.5
+resolvelib==1.2.1
+rich==14.2.0
+rpds-py==0.30.0
+ruamel.yaml==0.18.16
+ruamel.yaml.clib==0.2.15
+selinux==0.3.0
+subprocess-tee==0.4.2
+urllib3==2.6.0
+virtualenv==20.35.4
+wcmatch==10.1
+yamllint==1.37.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
-ansible-core==2.13.13 ; python_full_version >= "3.8.1" and python_version < "4.0"
-ansible==6.6.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-cffi==1.16.0 ; python_full_version >= "3.8.1" and python_version < "4.0"
-cryptography==41.0.7 ; python_full_version >= "3.8.1" and python_version < "4.0"
-jinja2==3.1.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-markupsafe==2.1.3 ; python_full_version >= "3.8.1" and python_version < "4.0"
-packaging==23.2 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pycparser==2.21 ; python_full_version >= "3.8.1" and python_version < "4.0"
-pyyaml==6.0.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
-resolvelib==0.8.1 ; python_full_version >= "3.8.1" and python_version < "4.0"
+ansible==13.0.0
+ansible-core==2.20.0
+cffi==2.0.0
+cryptography==46.0.3
+Jinja2==3.1.6
+MarkupSafe==3.0.3
+packaging==25.0
+pycparser==2.23
+PyYAML==6.0.3
+resolvelib==1.2.1
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ packaging==25.0
 pycparser==2.23
 PyYAML==6.0.3
 resolvelib==1.2.1
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,18 +2,18 @@
 # tasks file for ansible-rabbitmq
 - name: Include Debian tasks
   ansible.builtin.include_tasks: debian.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Include RedHat tasks
   ansible.builtin.include_tasks: redhat.yml
   when: >
-        ansible_distribution == "CentOS" or
-        ansible_distribution == "Red Hat Enterprise Linux" or
-        ansible_distribution == "OracleLinux"
+        ansible_facts['distribution'] == "CentOS" or
+        ansible_facts['distribution'] == "Red Hat Enterprise Linux" or
+        ansible_facts['distribution'] == "OracleLinux"
 
 - name: Include Fedora tasks
   ansible.builtin.include_tasks: fedora.yml
-  when: ansible_distribution == "Fedora"
+  when: ansible_facts['distribution'] == "Fedora"
 
 - name: Manage RabbitMQ plugins
   ansible.builtin.include_tasks: rabbitmq_plugins.yml

--- a/tasks/rabbitmq_plugins.yml
+++ b/tasks/rabbitmq_plugins.yml
@@ -3,5 +3,5 @@
   community.rabbitmq.rabbitmq_plugin:
     name: "{{ rabbitmq_plugins }}"
   become: true
-  when: rabbitmq_plugins
+  when: rabbitmq_plugins | length > 0
   notify: restart rabbitmq-server

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,6 +1,6 @@
 ---
 - name: redhat | installing pre-reqs
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: ['epel-release', 'wget']
     state: present
   become: true
@@ -8,7 +8,7 @@
   until: result is successful
 
 - name: redhat | installing erlang
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: erlang
     state: present
   become: true
@@ -31,7 +31,7 @@
   become: true
 
 - name: redhat | installing RabbitMQ
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "/opt/{{ rabbitmq_redhat_package }}"
     state: present
   become: true


### PR DESCRIPTION
## Description

RabbitMQ changed the Debian / Ubuntu repos again.

I have:
- change the repo to the new urls
- changed the signing keys accordingly
- incremented the version to new current release
- fixed an ansible boolean comparison (relevant for current and future ansible releases)

## Info

I have not adjusted the RPM release because I have no option to test it and can therefor not confirm if it works.

## Breaking Changes

- Default RabbitMQ version updated from 3.13.7 to 4.2.1 (major version)
- Users should override `rabbitmq_debian_version` to stay on 3.x if not ready to upgrade
- See RabbitMQ 4.0 Release Notes for upgrade considerations

## Testing

- [x] Tested on Ubuntu 20.04 (molecule) > ! The old Python3 version does no longer work with current ansible [1]
- [x] Tested on Ubuntu 22.04 (molecule)
- [x] Tested on Ubuntu 24.04 (molecule + prod system)
- [ ] Tested on Debian 11
- [ ] Tested on Debian 12

## requirements.txt

I have updated the requirements.txt to use the current ansible version.

[1] The current ansible versions require python 3.9 or newer. Ubuntu 20.04 has only python 3.8.